### PR TITLE
Fix example

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ const squareWithHole = [
     // Hole
     [[2, 2], [8, 2], [8, 8], [2, 8]]
 ];
-const {indices, position, uv, normal} = extrudePolygon(squareWithHole, {
+const {indices, position, uv, normal} = extrudePolygon([squareWithHole], {
     depth: 2
 });
 ```


### PR DESCRIPTION
Hi!
Main example in *##Basic Usage* seems broken: if you put it in a `example.js` with `console.log(indices)` results in an empty array. Moreover a `example.ts` catch the error instantly.

Typescript is great! How did you generated definitions?